### PR TITLE
Fix race condition caused by delayed hiding of previous state.

### DIFF
--- a/library/src/com/meetme/android/multistateview/MultiStateView.java
+++ b/library/src/com/meetme/android/multistateview/MultiStateView.java
@@ -37,6 +37,8 @@ public class MultiStateView extends FrameLayout {
 
     public MultiStateView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
+        // Start out with a default handler/looper
+        mHandler = new MultiStateHandler();
         parseAttrs(context, attrs);
     }
 
@@ -362,13 +364,15 @@ public class MultiStateView extends FrameLayout {
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
+        // Prefer the AttachInfo handler on attach:
         mHandler = new MultiStateHandler(getHandler().getLooper());
     }
 
     @Override
     protected void onDetachedFromWindow() {
         mHandler.removeMessages(MultiStateHandler.MESSAGE_HIDE_PREVIOUS);
-        mHandler = null;
+        // Reset it to a default looper
+        mHandler = new MultiStateHandler();
         super.onDetachedFromWindow();
     }
 
@@ -556,7 +560,6 @@ public class MultiStateView extends FrameLayout {
     private class MultiStateHandler extends Handler {
         public static final int MESSAGE_HIDE_PREVIOUS = 0;
 
-        @SuppressWarnings("unused")
         public MultiStateHandler() {
             super();
         }


### PR DESCRIPTION
The fix for #1 (race condition) also introduces a second race condition
when `setState()` is called a second time before the 1st call's previous
state view was hidden by the `Runnable`.  For example:

```
msv.setState(ContentState.LOADING); // (1)
msv.setState(ContentState.CONTENT); // (2)
```

This is the simplest way to reproduce the problem.  The default state is
`ContentState.CONTENT`. The (1) call shows the `LOADING` view and posts
a runnable that intends to hide the `CONTENT` view.  Then the (2) call
does the opposite:  shows the `CONTENT` view and posts a runnable
to hide the `LOADING` view.  The (2) show happens before the (1)
runnable has a chance to hide the `CONTENT` view, so when the runnable
finally does get run, it hides the `CONTENT` view, superceding the work
done by the (2) call.

This change converts the `postRunnable()` behavior into an inner
`Handler` subclass that will take a `ContentState` obj that is meant
to be hidden.  That way when `setState()` is called, we can remove any
pending messages that are meant to hide the state that is currently
requested to be shown.  If however, you are switching states to a different
state, then the pending hide will still be executed properly, such as:

```
msv.setState(ContentState.LOADING);
msv.setState(ContentState.GENERAL_ERROR);
// will still hide CONTENT *and* will hide LOADING
```

This manifests easily when you set up your view to have an initial state
of `LOADING` in `onViewCreated()`, and in `onViewStateRestored()`, you
set the state back to `CONTENT`.
