### PR TITLE
Remove the delayed-hide of previous content state

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,7 +2,9 @@ apply plugin: 'android-library'
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "19.1.0"
+    // Allow publishing both debug and release variants
+    publishNonDefault true
 
     sourceSets {
         main {
@@ -12,4 +14,8 @@ android {
             assets.srcDirs = ['assets']
         }
     }
+}
+
+dependencies {
+    compile 'com.android.support:support-annotations:+'
 }

--- a/library/src/com/meetme/android/multistateview/MultiStateView.java
+++ b/library/src/com/meetme/android/multistateview/MultiStateView.java
@@ -4,11 +4,16 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.util.SparseArray;
 import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.TextView;
+
+import java.util.Locale;
 
 /**
  * A view designed to wrap a single child (the "content") and hide/show that content based on the current "state" (see {@link ContentState}) of this
@@ -16,7 +21,8 @@ import android.widget.TextView;
  */
 @SuppressWarnings("NullableProblems")
 public class MultiStateView extends FrameLayout {
-    private final MultiStateViewData mViewState = new MultiStateViewData((ContentState) null);
+    private static final String TAG = "MultiStateView";
+    private final MultiStateViewData mViewState = new MultiStateViewData(ContentState.CONTENT);
 
     private View mContentView;
     private View mLoadingView;
@@ -139,13 +145,14 @@ public class MultiStateView extends FrameLayout {
     /**
      * @return the {@link ContentState} the view is currently in
      */
+    @NonNull
     public ContentState getState() {
         return mViewState.state != null ? mViewState.state : ContentState.CONTENT;
     }
 
     /**
-     * Configures the view to be in the given state. This method is an internal method used for parsing the native integer value used in attributes in
-     * XML
+     * Configures the view to be in the given state. This method is an internal method used for parsing the native integer value used in attributes
+     * in XML.
      *
      * @param nativeInt
      * @see ContentState
@@ -162,6 +169,7 @@ public class MultiStateView extends FrameLayout {
      */
     public void setState(final ContentState state) {
         if (state == mViewState.state) {
+            if (BuildConfig.DEBUG) Log.v(TAG, "Already in state " + mViewState.state);
             // No change
             return;
         }
@@ -169,13 +177,18 @@ public class MultiStateView extends FrameLayout {
         final View contentView = getContentView();
 
         if (contentView == null) {
+            if (BuildConfig.DEBUG) Log.v(TAG, "Content not yet set, waiting...");
             return;
         }
 
         // Hide the previous state view
         final ContentState previousState = mViewState.state;
         View previousView = getStateView(previousState);
-        if (previousView != null) previousView.setVisibility(View.GONE);
+
+        if (previousView != null) {
+            if (BuildConfig.DEBUG) Log.v(TAG, "Hiding previous state " + previousState);
+            previousView.setVisibility(View.GONE);
+        }
 
         // Show the new state view
         View newStateView = getStateView(state);
@@ -189,10 +202,57 @@ public class MultiStateView extends FrameLayout {
                 }
             }
 
+            if (BuildConfig.DEBUG) Log.v(TAG, "Showing new state " + state);
             newStateView.setVisibility(View.VISIBLE);
         }
 
         mViewState.state = state;
+
+        if (BuildConfig.DEBUG) {
+            dumpState();
+
+            // Now check if there are multiple visible children and emit a warning if so
+            boolean hasVisible = false;
+
+            for (int i = 0; i < getChildCount(); i++) {
+                View v = getChildAt(i);
+
+                if (v != null && v.getVisibility() != View.GONE) {
+                    // This should not happen
+                    if (hasVisible) Log.w(TAG, "MultiStateView has multiple visible children!");
+                    hasVisible = true;
+                }
+            }
+        }
+    }
+
+    /** Dump the current state of the view. Requires {@link BuildConfig#DEBUG}. */
+    public void dumpState() {
+        if (!BuildConfig.DEBUG) return;
+
+        Log.v(TAG, "/-- Start Dump State ---");
+        Log.v(TAG, "| Current state = " + mViewState.state);
+        Log.v(TAG, "| Children: " + getChildCount());
+
+        for (int i = 0; i < getChildCount(); i++) {
+            View child = getChildAt(i);
+            ContentState state = null;
+
+            if (child == mContentView) {
+                state = ContentState.CONTENT;
+            } else if (child == mGeneralErrorView) {
+                state = ContentState.ERROR_GENERAL;
+            } else if (child == mNetworkErrorView) {
+                state = ContentState.ERROR_NETWORK;
+            } else if (child == mLoadingView) {
+                state = ContentState.LOADING;
+            }
+
+            Log.v(TAG, String.format(Locale.US, "| - #%d: %s (%s) -> %s",
+                    i, child, state, (child != null && child.getVisibility() == View.VISIBLE ? "visible" : "gone")));
+        }
+
+        Log.v(TAG, "\\-- End Dump State ---");
     }
 
     /**
@@ -201,7 +261,10 @@ public class MultiStateView extends FrameLayout {
      * @param state
      * @return
      */
+    @Nullable
     public View getStateView(ContentState state) {
+        if (state == null) return null;
+
         switch (state) {
             case ERROR_NETWORK:
                 return getNetworkErrorView();
@@ -224,6 +287,7 @@ public class MultiStateView extends FrameLayout {
      *
      * @return
      */
+    @NonNull
     public View getNetworkErrorView() {
         if (mNetworkErrorView == null) {
             mNetworkErrorView = View.inflate(getContext(), mViewState.networkErrorLayoutResId, null);
@@ -244,6 +308,7 @@ public class MultiStateView extends FrameLayout {
      *
      * @return
      */
+    @NonNull
     public View getGeneralErrorView() {
         if (mGeneralErrorView == null) {
             mGeneralErrorView = View.inflate(getContext(), mViewState.generalErrorLayoutResId, null);
@@ -262,6 +327,7 @@ public class MultiStateView extends FrameLayout {
     /**
      * Builds the loading view if not currently built, and returns the view
      */
+    @NonNull
     public View getLoadingView() {
         if (mLoadingView == null) {
             mLoadingView = View.inflate(getContext(), mViewState.loadingLayoutResId, null);
@@ -302,6 +368,7 @@ public class MultiStateView extends FrameLayout {
      * @return the view being used as "content" within the view (the developer-provided content -- doesn't ever give back internally maintained views
      * (like the loading layout))
      */
+    @Nullable
     public View getContentView() {
         return mContentView;
     }
@@ -324,11 +391,9 @@ public class MultiStateView extends FrameLayout {
     @Override
     protected Parcelable onSaveInstanceState() {
         Parcelable state = super.onSaveInstanceState();
-
         SavedState myState = new SavedState(state);
-
         myState.state = mViewState;
-
+        if (BuildConfig.DEBUG) Log.v(TAG, "Saved state: " + myState.state);
         return myState;
     }
 
@@ -344,6 +409,7 @@ public class MultiStateView extends FrameLayout {
     }
 
     private void setViewState(MultiStateViewData state) {
+        if (BuildConfig.DEBUG) Log.v(TAG, "Restoring state: " + state);
         setState(state.state);
         setTapToRetryString(state.tapToRetryString);
         setGeneralErrorTitleString(state.generalErrorTitleString);
@@ -528,5 +594,14 @@ public class MultiStateView extends FrameLayout {
                 return new MultiStateViewData[size];
             }
         };
+
+        @Override
+        public String toString() {
+            if (BuildConfig.DEBUG) {
+                return String.format(Locale.US, "MultiStateViewData{state=%s}", state);
+            }
+
+            return super.toString();
+        }
     }
 }


### PR DESCRIPTION
This effectively reverts the intent of b9503be6.

The concept of delaying the hide of the previous content state is
causing more trouble than it is worth, resulting in several race
conditions.  Rather than resolve the race conditions, it is more
prudent to remove the delayed hide entirely, as there is no reason
to think that atomically swapping visibility would be broken.
